### PR TITLE
Updating the Lead Assignment Rules

### DIFF
--- a/salesforce/Objects/Lead/AssignmentRules/Lead.nacl
+++ b/salesforce/Objects/Lead/AssignmentRules/Lead.nacl
@@ -11,7 +11,7 @@ salesforce.AssignmentRules Lead {
             {
               field = salesforce.Lead.field.Score__c
               operation = "greaterOrEqual"
-              value = "60"
+              value = "40"
             },
           ]
         },
@@ -22,7 +22,7 @@ salesforce.AssignmentRules Lead {
             {
               field = salesforce.Lead.field.Score__c
               operation = "lessThan"
-              value = "60"
+              value = "40"
             },
           ]
         },


### PR DESCRIPTION
I have changed the lead assignment values where if the Lead Score is Less than 40: lead is cold; whereas is Lead Score is greater than or equal to 40: lead is hot